### PR TITLE
2018/09/02 分を追加

### DIFF
--- a/2018/09/02.md
+++ b/2018/09/02.md
@@ -1,0 +1,106 @@
+# 2018/09/02 今日の AWS
+
+## 今日の AWS ~ 色々メモ ~
+
+### Auto Scaling クールダウン
+
+> トリガー関連の規模の拡大や縮小が以後のスケーリングイベントに影響を及ぼすことができる期限であり, 規模の拡大や縮小の終了から経過した時間 (秒) です
+
+ドキュメントより. ↑ なんのこっちゃ全くわからん.
+
+簡単に言うと, 新しいインスタンスが追加されるまでの時間.ドキュメントよりも [【AWS】Auto Scalingまとめ](https://qiita.com/iron-breaker/items/2b55da35429da7b19e49) この資料の方が超わかりやすい.
+
+クールダウンが無い場合...
+
+* AutoScaling グループ内の EC2 の CPU 負荷をトリガーとしている場合, 追加のインスタンスの起動に時間を要してしまうと, 次々にインスタンスが爆誕してしまう 
+
+クールダウンがある場合...
+
+* 指定された期間 (クールダウン期間) は EC2 の追加は行われない
+
+### Auto Scaling のトリガーに CloudWatch のカスタムメトリクスは利用出来るか
+
+* 出来る
+* ELB のレスポンスタイムとかで EC2 の台数を増やすことが出来る
+
+### CloudWatch のカスタムメトリクスで取得する必要がある監視対象
+
+* EC2 インスタンスのメモリ使用率 (あるある)
+* EC2 のディスク使用率
+
+### CLoudWatch で取得出来る EC2 の各種メトリクス
+
+* CPUUtilization
+* DiskReadOps, Bytes (**全てのインスタンスストアボリューム**での, 完了した読み取り操作の回数, バイト)
+* DiskWriteOps, Bytes (**全てのインスタンスストアボリューム**への, 完了した書き込み操作の回数, バイト)
+* NetworkIn
+* NetworkOut
+* NetworkPacketsIn
+* NetworkPacketsOut
+
+ごっちゃになっていたのは, DiskReadOps とかのディスク系のメトリクス. てっきり, EBS のメトリクスも含まれると思っていた. EBS は EBS で別のメトリクスがある. インスタンスストアボリュームが無いインスタンスにおいては, これらのメトリクスは 0 又は出力されない.
+
+### Route53 を使った, リージョンを越えたサービスの展開
+
+* ELB はリージョンをまたげない
+* このような場合には Route53 のレイテンシーベースルーティング + (各リージョンに配置した ELB + EC2) で対応するのが正解かなー
+* Route53 その他のレコード設定
+    * 加重ラウンドロビン (各レコードに重み付け, あるレコードに対するクエリに指定された比率で異なる値を応答する)
+    * レイテンシーベースルーティング (クライアントとのレイテンシが小さいレコードが返される)
+    * 位置情報ルーティング (クライアントの IP アドレス)
+    * ヘルスチェックとフェイルオーバー
+
+
+### インターネット VPN と DirectConnect
+
+![aws-black-belt-tech-aws-direct-connect-11-638.jpg?cb=1504585130](https://image.slidesharecdn.com/20150128-aws-blackbelt-directconnect-public-150128200607-conversion-gate01/95/aws-black-belt-tech-aws-direct-connect-11-638.jpg?cb=1504585130)
+
+![aws-black-belt-tech-aws-direct-connect-12-638.jpg?cb=1504585130](https://image.slidesharecdn.com/20150128-aws-blackbelt-directconnect-public-150128200607-conversion-gate01/95/aws-black-belt-tech-aws-direct-connect-12-638.jpg?cb=1504585130)
+
+### インターネット VPN において, SPOF の排除
+
+* デュアルトンネル VPN
+* [AWS マネージド VPN 接続 - Amazon Virtual Private Cloud](https://docs.aws.amazon.com/ja_jp/AmazonVPC/latest/UserGuide/VPC_VPN.html#VPNConnections) (冗長な VPN 接続を仕様してフェイルオーバーを提供する)
+
+### DynamoDB キャパシティユニット
+
+* 書き込み
+    * 1 ユニット: 最大 1 KBのデータを 1 秒に 1 回書き込み可能
+* 読み込み
+    * 1 ユニット: 最大 4 KBのデータを 1 秒に 1 回読み込み可能 (強い一貫性を持たない読み込みであれば, 1 秒辺り 2 回)
+
+### CloudFormation テンプレート
+
+* Format Version
+* Description
+* Metadata
+* Parameters
+* Mappings
+* Conditions
+* Transform
+* Resources
+* Outputs
+
+### Simple Workflow Service
+
+以下, SWF の用語.
+
+* ワークフロースターター
+* ワークフローエグゼキューション
+* ドメイン
+* タスクリスト
+* デザイダー
+* アクティビティ
+
+細かいことは追えていない...
+
+### S3 オブジェクトの暗号化オプション
+
+* サーバー (Amazon S3) 側とクライアント側で暗号化を行うことが出来る
+* サーバー側 (S3 に保管する際に暗号化する)
+    * S3 で管理されたキーによる暗号化 (SSE-S3)
+    * KMS で管理されたキーによる暗号化 (SSE-KMS)
+    * ユーザが用意したキーによる暗号化 (SSE-C)
+* クライアント側で S3 に書き込む前に暗号化する
+
+ﾌﾑﾌﾑ.


### PR DESCRIPTION
クールダウンが無い場合...
 * AutoScaling グループ内の EC2 の CPU 負荷をトリガーとしている場合, 追加のインスタンスの起動に時間を要してしまうと, 次々にインスタンスが爆誕してしまう 

 クールダウンがある場合...

 * 指定された期間 (クールダウン期間) は EC2 の追加は行われない

EC2 の CloudWatch メトリクスにおいて, Diskxxx はあくまでもインスタンスストアのメトリクスであるので注意する.